### PR TITLE
Feat: add unit mix compliance reporting

### DIFF
--- a/SPECIFICATIONS_V1.md
+++ b/SPECIFICATIONS_V1.md
@@ -1,0 +1,189 @@
+# COSTO Self-Storage Auto-Layout Specification (V1)
+
+**Version:** V1 (Defined June 2025)
+
+## 1) Context and Objective
+COSTO designs and installs self-storage facilities. Producing a unit mix currently requires many manual iterations (drawing, measurements, circulation/safety checks). The objective is to automatically generate a compliant, optimized storage-unit layout from a bare plan and target unit mix.
+
+**Inputs**
+- Bare DWG/DXF plan (perimeter, columns/obstacles, technical rooms, shafts, stairs, exits, etc.).
+- Target unit mix (quantities/areas per type).
+- Operational and safety constraints.
+
+**Outputs**
+- Optimized cubicle plan (layout).
+- Bill of quantities (areas and counts per type).
+- DWG/PDF/SVG exports.
+- Discrepancy report if 100% unit mix compliance is impossible.
+
+## 2) Scope
+### 2.1 In Scope (V1)
+- DWG/DXF import and interpretation of constraint layers.
+- Configurable box catalog (sizes, depths, widths, doors).
+- Unit mix input/import (Excel/CSV).
+- Automatic layout generation (single or multi-level).
+- Manual editing (move, resize, merge, split) after optimization.
+- Checks/reports: areas, circulation, fire safety rules (simple configurable rules).
+- Exports: annotated DWG, PDF, interactive SVG (hover/click for datasheet).
+
+### 2.2 Out of Scope (V2+)
+- Structural calculations (loads), full MEP/SSI sizing.
+- Complete execution plan (assembly details).
+- Automatic supplier quotes (extension).
+
+## 3) Target Users and Use Cases
+### 3.1 Profiles
+- Design Office / Methods: generate and adjust plans.
+- Sales / Pre-sales: test multiple unit mixes quickly.
+- Technical Management: validate compliance, productivity, and yield.
+
+### 3.2 Main Use Cases
+1. Load blank DWG (level).
+2. Define usable areas, obstacles, restricted areas.
+3. Load unit mix (surface/target counts, tolerances).
+4. Configure rules (circulation, rounding, templates).
+5. Generate.
+6. Review plan + quantity takeoff + score (compliance rate, yield).
+7. Manually adjust if needed.
+8. Export DWG/PDF/SVG + report.
+
+## 4) Input Data
+### 4.1 Plan Files
+- DWG/DXF, 2D preferred (3D optional).
+- Units: meters.
+- Origin: not important but consistent within file.
+
+### 4.2 Layer Convention (standard or mapped)
+- Usable envelope/perimeter (closed polyline).
+- Obstacles (columns, ducts, technical rooms).
+- Prohibited areas (smoke extraction, shafts, voids, etc.).
+- Exits/stairs/freight elevators (circulation and access constraints).
+- Fire doors/access control (if included).
+
+### 4.3 Unit Mix (CSV/Excel)
+- Type (e.g., S/M/L or 1–2 m², 2–3 m²).
+- Target area or target unit count.
+- Tolerance (±% or ± m²).
+- Priority (mandatory/desirable).
+
+## 5) Unit Catalog (Configurable)
+For each family:
+- Nominal area (or range).
+- Possible dimensions (W x D) or template list.
+- Standard door width.
+- Partition type (thickness, module).
+- Optional accessible units (specific rules).
+- Optional premium units (near entrance, wide access points).
+
+## 6) Business Rules and Layout Constraints
+### 6.1 Circulation
+- Minimum main corridor width (e.g., 1.50 m / 1.80 m).
+- Minimum secondary corridor width (e.g., 1.20 m).
+- Continuity of circulation (no dead ends where prohibited).
+- Guaranteed access to exits/stairs/main access.
+
+### 6.2 Row Construction
+- Layout by strips (rows) along main axes.
+- Returns at end of aisles.
+- Fill optimization (minimize wasted space).
+
+### 6.3 Surface Compliance
+- Net interior area definition for units.
+- Rounding rules (e.g., 0.5 m² increments) as parameters.
+- Tolerance per typology.
+
+### 6.4 Safety / Operation (Simple Rules)
+- No encroachment on smoke extraction, LT zones, etc.
+- Clearances in front of fire doors/exits.
+- Optional maximum distance to exit if points provided.
+
+## 7) Optimization Logic
+### 7.1 Objective (Weighted Score)
+1. Unit mix compliance (weighted deviation).
+2. Maximize leasable m² / usable m².
+3. Minimize partition wall linear meters (cost).
+4. Plan readability (axes, repeatability, standardization).
+
+### 7.2 Method (Expected)
+- Generate candidates (strips + cutting).
+- Heuristic/meta-heuristic (simulated annealing/tabu) or MILP.
+- Post-processing: cleanup, alignment, collision detection, numbering.
+
+### 7.3 Handling Impossibility
+- Provide best solution + deviation report:
+  - Missing/excess typology areas.
+  - Lost m².
+  - Probable causes (constraints, geometry).
+
+## 8) User Interface (V1)
+### 8.1 Main Screen
+- Plan view (zoom, pan, snaps).
+- Layer toggles.
+- Unit Mix panel (import, tolerances, priorities).
+- Rules panel (circulation, rounding, templates).
+- Generate button + score/deviation display.
+- Edit mode: move/resize/lock a row.
+
+### 8.2 Box Objects
+- Selection highlight + properties.
+- Details: ID, dimensions, area, type, row, violated constraints.
+- Automatic numbering (configurable: zone + row + number).
+
+## 9) Expected Outputs
+### 9.1 Graphic Exports
+- DWG: separate layers (boxes, text, dimensions, circulation).
+- PDF: A3/A1 plans, title block, legend.
+- Interactive SVG: hover/click box for information.
+
+### 9.2 Data Exports
+- Excel/CSV:
+  - List of boxes (ID, area, length, depth, type, level, zone).
+  - Consolidated by type.
+  - Discrepancies vs unit mix.
+- PDF report:
+  - Assumptions (rules, versions).
+  - KPIs: leasable m², yield, partition length, compliance rate.
+
+## 10) Non-Functional Requirements
+- Performance: generation < 60 s for standard level.
+- Reliability: autosave + project versioning.
+- Traceability: exports include version ID + parameters.
+- Compatibility: Windows priority; Web option in V2.
+- Interop: robust DWG/DXF library, native SVG/PDF.
+
+## 11) Architecture (Recommendation)
+- Geometric engine: polygons, offsets, collisions, no-go zones.
+- Optimization solver: separate module (internal API).
+- UI: CAD viewer (snap, layers, selection).
+- Project format: single file (JSON + DWG references + exports).
+
+## 12) Acceptance Criteria
+### 12.1 Minimum Functional Tests
+1. DWG import + layer mapping (envelope + obstacles).
+2. Unit mix import (Excel) + validation.
+3. Generation without collisions, boxes inside envelope, traffic flow respected.
+4. DWG export with correct layers in AutoCAD.
+5. Excel export consistency (areas + unit counts).
+6. Deviation report correctness when mix unattainable.
+
+### 12.2 Validation KPIs
+- Unit mix compliance rate ≥ target (e.g., 95%).
+- Leasable m² / usable m² yield ≥ target.
+- Generation time ≤ target.
+
+## 13) Expected Deliverables
+- Software installer + license.
+- User manual + DWG COSTO convention guide.
+- Test case set (DWG + unit mix + expected results).
+- Technical documentation (internal API, formats, configuration).
+- V1 support (bug fixes) + V2 enhancement option.
+
+## 14) Roadmap (Indicative)
+- Phase 0: COSTO DWG layer standard + catalog + rules.
+- Phase 1: MVP (DWG import + unit mix + simple band generation + exports).
+- Phase 2: Improved solver + advanced editing + security controls.
+- Phase 3: Multi-level design + site optimization + cost estimation.
+
+---
+
+**Note:** Defining a COSTO DWG standard (layer names + object types) is recommended to reduce mapping friction.

--- a/lib/unitMixReport.js
+++ b/lib/unitMixReport.js
@@ -1,0 +1,189 @@
+const DEFAULT_PRIORITY = 1;
+
+function toNumber(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+function normalizeType(value) {
+    if (value === null || value === undefined) return null;
+    const text = String(value).trim();
+    return text.length ? text : null;
+}
+
+function normalizeTolerance(tolerance) {
+    if (!tolerance) {
+        return { type: 'percentage', value: 0 };
+    }
+
+    if (typeof tolerance === 'object' && tolerance.type && typeof tolerance.value !== 'undefined') {
+        const value = toNumber(tolerance.value);
+        return {
+            type: tolerance.type === 'absolute' ? 'absolute' : 'percentage',
+            value: value !== null && value >= 0 ? value : 0
+        };
+    }
+
+    if (typeof tolerance === 'string' && tolerance.includes('%')) {
+        const value = toNumber(tolerance.replace('%', ''));
+        return {
+            type: 'percentage',
+            value: value !== null && value >= 0 ? value : 0
+        };
+    }
+
+    const numeric = toNumber(tolerance);
+    return {
+        type: 'absolute',
+        value: numeric !== null && numeric >= 0 ? numeric : 0
+    };
+}
+
+function getIlotArea(ilot) {
+    const area = toNumber(ilot.area);
+    if (area !== null && area >= 0) return area;
+
+    const width = toNumber(ilot.width);
+    const height = toNumber(ilot.height);
+    if (width !== null && height !== null) {
+        return Math.max(0, width * height);
+    }
+
+    return null;
+}
+
+function buildActuals(ilots) {
+    const actuals = new Map();
+
+    if (!Array.isArray(ilots)) {
+        return actuals;
+    }
+
+    ilots.forEach((ilot) => {
+        if (!ilot || typeof ilot !== 'object') return;
+        const type = normalizeType(ilot.type || ilot.sizeCategory);
+        if (!type) return;
+
+        const area = getIlotArea(ilot);
+        const entry = actuals.get(type) || { area: 0, count: 0 };
+        entry.count += 1;
+        if (area !== null) {
+            entry.area += area;
+        }
+        actuals.set(type, entry);
+    });
+
+    return actuals;
+}
+
+function buildReport(ilots, unitMix) {
+    if (!Array.isArray(unitMix) || unitMix.length === 0) {
+        return null;
+    }
+
+    const actuals = buildActuals(ilots);
+    const results = [];
+
+    let totalTargetArea = 0;
+    let totalActualArea = 0;
+    let totalTargetCount = 0;
+    let totalActualCount = 0;
+    let weightedCompliance = 0;
+    let totalWeight = 0;
+
+    const discrepancies = {
+        missingAreas: [],
+        excessAreas: [],
+        missingCounts: [],
+        excessCounts: []
+    };
+
+    unitMix.forEach((item) => {
+        if (!item || typeof item !== 'object') return;
+        const type = normalizeType(item.type || item.Type);
+        if (!type) return;
+
+        const targetArea = toNumber(item.targetArea || item.target_area || item.area || item['target area']);
+        const targetCount = toNumber(item.targetCount || item.target_count || item.count || item['target count']);
+        const tolerance = normalizeTolerance(item.tolerance);
+        const priority = toNumber(item.priority) || DEFAULT_PRIORITY;
+
+        const actual = actuals.get(type) || { area: 0, count: 0 };
+        const actualArea = actual.area || 0;
+        const actualCount = actual.count || 0;
+
+        totalActualArea += actualArea;
+        totalActualCount += actualCount;
+
+        let deltaArea = null;
+        let deltaCount = null;
+        let withinTolerance = null;
+        let complianceRatio = 0;
+
+        if (targetArea !== null) {
+            totalTargetArea += targetArea;
+            deltaArea = actualArea - targetArea;
+            const allowed = tolerance.type === 'percentage'
+                ? (targetArea * (tolerance.value / 100))
+                : tolerance.value;
+            withinTolerance = Math.abs(deltaArea) <= allowed;
+            complianceRatio = targetArea > 0 ? Math.max(0, 1 - (Math.abs(deltaArea) / targetArea)) : 0;
+
+            if (deltaArea < 0) {
+                discrepancies.missingAreas.push({ type, amount: Math.abs(deltaArea) });
+            } else if (deltaArea > 0) {
+                discrepancies.excessAreas.push({ type, amount: deltaArea });
+            }
+        }
+
+        if (targetCount !== null) {
+            totalTargetCount += targetCount;
+            deltaCount = actualCount - targetCount;
+            const allowedCount = tolerance.type === 'percentage'
+                ? (targetCount * (tolerance.value / 100))
+                : tolerance.value;
+            const withinCount = Math.abs(deltaCount) <= allowedCount;
+            withinTolerance = withinTolerance === null ? withinCount : (withinTolerance && withinCount);
+            const countRatio = targetCount > 0 ? Math.max(0, 1 - (Math.abs(deltaCount) / targetCount)) : 0;
+            complianceRatio = targetArea !== null ? complianceRatio : countRatio;
+
+            if (deltaCount < 0) {
+                discrepancies.missingCounts.push({ type, amount: Math.abs(deltaCount) });
+            } else if (deltaCount > 0) {
+                discrepancies.excessCounts.push({ type, amount: deltaCount });
+            }
+        }
+
+        weightedCompliance += complianceRatio * priority;
+        totalWeight += priority;
+
+        results.push({
+            type,
+            targetArea: targetArea !== null ? targetArea : null,
+            targetCount: targetCount !== null ? targetCount : null,
+            actualArea,
+            actualCount,
+            deltaArea,
+            deltaCount,
+            tolerance,
+            priority,
+            withinTolerance
+        });
+    });
+
+    const weightedComplianceRate = totalWeight > 0 ? weightedCompliance / totalWeight : 0;
+
+    return {
+        summary: {
+            weightedComplianceRate,
+            totalTargetArea,
+            totalActualArea,
+            totalTargetCount,
+            totalActualCount
+        },
+        byType: results,
+        discrepancies
+    };
+}
+
+module.exports = { buildReport };

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const floorPlanStore = require('./lib/floorPlanStore');
 const ProductionInitializer = require('./lib/productionInitializer');
 const MLProcessor = require('./lib/mlProcessor');
 const UnitMixManager = require('./lib/unitMixManager');
+const UnitMixReport = require('./lib/unitMixReport');
 const RuleManager = require('./lib/ruleManager');
 const ML_BOOT_PREFIX = '[Production ML System]';
 
@@ -1201,6 +1202,7 @@ app.post('/api/ilots', async (req, res) => {
 
         // Calculate total area
         const totalArea = ilots.reduce((sum, ilot) => sum + (Number(ilot.area) || 0), 0);
+        const unitMixReport = UnitMixReport.buildReport(ilots, unitMix);
 
         global.lastPlacedIlots = ilots;
         if (planId) {
@@ -1208,7 +1210,8 @@ app.post('/api/ilots', async (req, res) => {
             floorPlanStore.updateLayout(planId, {
                 ilots,
                 distribution: normalizedDistribution,
-                options: generatorOptions
+                options: generatorOptions,
+                unitMixReport
             });
         }
 
@@ -1227,6 +1230,7 @@ app.post('/api/ilots', async (req, res) => {
             count: ilots.length,
             distribution: normalizedDistribution,
             options: generatorOptions,
+            unitMixReport: unitMixReport,
             validation: validationReport,
             suggestions: suggestions,
             message: `Generated ${ilots.length} ilots with ${totalArea.toFixed(2)} m² total area`

--- a/tests/unit/unitMixReport.test.js
+++ b/tests/unit/unitMixReport.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+const { buildReport } = require('../../lib/unitMixReport');
+
+describe('UnitMixReport', () => {
+
+    it('should compute area compliance with tolerance', () => {
+        const ilots = [
+            { type: 'S', area: 5 },
+            { type: 'S', area: 5 },
+            { type: 'M', area: 10 }
+        ];
+        const unitMix = [
+            { type: 'S', targetArea: 12, tolerance: { type: 'percentage', value: 10 }, priority: 2 },
+            { type: 'M', targetArea: 10, tolerance: { type: 'absolute', value: 0 }, priority: 1 }
+        ];
+
+        const report = buildReport(ilots, unitMix);
+
+        assert.ok(report);
+        assert.strictEqual(report.summary.totalTargetArea, 22);
+        assert.strictEqual(report.summary.totalActualArea, 20);
+        assert.strictEqual(report.byType.length, 2);
+
+        const small = report.byType.find((row) => row.type === 'S');
+        assert.strictEqual(small.actualArea, 10);
+        assert.strictEqual(small.deltaArea, -2);
+        assert.strictEqual(small.withinTolerance, false);
+
+        const medium = report.byType.find((row) => row.type === 'M');
+        assert.strictEqual(medium.actualArea, 10);
+        assert.strictEqual(medium.deltaArea, 0);
+        assert.strictEqual(medium.withinTolerance, true);
+    });
+
+    it('should compute count compliance when target counts are provided', () => {
+        const ilots = [
+            { type: 'L', area: 12 },
+            { type: 'L', area: 11 },
+            { type: 'L', area: 10 }
+        ];
+        const unitMix = [
+            { type: 'L', targetCount: 4, tolerance: '25%', priority: 1 }
+        ];
+
+        const report = buildReport(ilots, unitMix);
+
+        assert.ok(report);
+        assert.strictEqual(report.summary.totalTargetCount, 4);
+        assert.strictEqual(report.summary.totalActualCount, 3);
+
+        const large = report.byType[0];
+        assert.strictEqual(large.deltaCount, -1);
+        assert.strictEqual(large.withinTolerance, true);
+    });
+});


### PR DESCRIPTION
### Motivation
- Provide a programmatic way to compute actuals, deltas and compliance for a requested unit mix so generation results can be evaluated automatically.
- Surface unit-mix deviation data alongside generated ilots so callers can inspect and persist compliance metrics.
- Enable deterministic unit tests for mix compliance logic to prevent regressions.

### Description
- Add `lib/unitMixReport.js` with `buildReport` which aggregates actual ilot areas/counts, compares them to targets, applies tolerances, computes weighted compliance and produces discrepancy lists.
- Integrate the report into the ilot generation flow by requiring `UnitMixReport` in `server.js`, calling `UnitMixReport.buildReport(ilots, unitMix)`, including `unitMixReport` in the `/api/ilots` JSON response, and persisting it in the saved layout via `floorPlanStore.updateLayout`.
- Add unit tests in `tests/unit/unitMixReport.test.js` covering area- and count-based compliance and tolerance behavior.
- Add the `UnitMixReport` import to `server.js` and wire the new report into logging/storage outputs.

### Testing
- Ran `npx jest tests/unit/unitMixReport.test.js --runInBand` and the test suite passed (2 tests, 2 passed). 
- No other automated endpoint or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966666887e4832081e8185d576f8355)