### PR TITLE
Add compliance report KPIs and `/api/report/compliance` endpoint

### DIFF
--- a/lib/complianceReport.js
+++ b/lib/complianceReport.js
@@ -1,0 +1,102 @@
+function toNumber(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+function resolveUsableArea(floorPlan = {}) {
+    const totalArea = toNumber(floorPlan.totalArea);
+    if (totalArea !== null && totalArea > 0) {
+        return { area: totalArea, source: 'totalArea' };
+    }
+
+    const bounds = floorPlan.bounds || {};
+    const widthValue = toNumber(bounds.width);
+    const heightValue = toNumber(bounds.height);
+    const maxX = toNumber(bounds.maxX);
+    const minX = toNumber(bounds.minX);
+    const maxY = toNumber(bounds.maxY);
+    const minY = toNumber(bounds.minY);
+    const width = widthValue !== null ? widthValue : (maxX !== null && minX !== null ? maxX - minX : null);
+    const height = heightValue !== null ? heightValue : (maxY !== null && minY !== null ? maxY - minY : null);
+    if (width !== null && height !== null && width > 0 && height > 0) {
+        return { area: width * height, source: 'bounds' };
+    }
+
+    const rooms = Array.isArray(floorPlan.rooms) ? floorPlan.rooms : [];
+    const roomArea = rooms.reduce((sum, room) => sum + (toNumber(room.area) || 0), 0);
+    if (roomArea > 0) {
+        return { area: roomArea, source: 'rooms' };
+    }
+
+    return { area: 0, source: 'unknown' };
+}
+
+function resolveIlotArea(ilot) {
+    const area = toNumber(ilot.area);
+    if (area !== null && area >= 0) return area;
+    const width = toNumber(ilot.width);
+    const height = toNumber(ilot.height);
+    if (width !== null && height !== null) return Math.max(0, width * height);
+    return 0;
+}
+
+function resolveIlotPerimeter(ilot) {
+    const width = toNumber(ilot.width);
+    const height = toNumber(ilot.height);
+    if (width !== null && height !== null) {
+        return Math.max(0, 2 * (width + height));
+    }
+    return 0;
+}
+
+function resolveCorridorArea(corridors) {
+    return corridors.reduce((sum, corridor) => sum + (toNumber(corridor.area) || 0), 0);
+}
+
+function resolveCorridorLength(corridors) {
+    return corridors.reduce((sum, corridor) => {
+        const length = toNumber(corridor.length);
+        if (length !== null) return sum + length;
+        const width = toNumber(corridor.width) || 0;
+        const height = toNumber(corridor.height) || 0;
+        return sum + Math.max(width, height);
+    }, 0);
+}
+
+function buildComplianceReport({ floorPlan = {}, ilots = [], corridors = [], unitMixReport = null, validation = null } = {}) {
+    const usableAreaResult = resolveUsableArea(floorPlan);
+    const usableArea = usableAreaResult.area;
+
+    const ilotList = Array.isArray(ilots) ? ilots : [];
+    const leasableArea = ilotList.reduce((sum, ilot) => sum + resolveIlotArea(ilot), 0);
+    const partitionLength = ilotList.reduce((sum, ilot) => sum + resolveIlotPerimeter(ilot), 0);
+
+    const corridorList = Array.isArray(corridors) ? corridors : [];
+    const corridorArea = resolveCorridorArea(corridorList);
+    const corridorLength = resolveCorridorLength(corridorList);
+
+    const yieldRatio = usableArea > 0 ? leasableArea / usableArea : 0;
+    const unitMixComplianceRate = unitMixReport?.summary?.weightedComplianceRate ?? null;
+
+    const assumptions = [];
+    assumptions.push(`Usable area source: ${usableAreaResult.source}.`);
+    assumptions.push('Partition length derived from ilot rectangle perimeters when width/height are available.');
+    assumptions.push('Corridor length uses corridor.length when provided, otherwise max(width, height).');
+
+    return {
+        kpis: {
+            leasableArea,
+            usableArea,
+            yieldRatio,
+            partitionLength,
+            corridorArea,
+            corridorLength,
+            unitMixComplianceRate
+        },
+        unitMixReport,
+        validation,
+        assumptions
+    };
+}
+
+module.exports = { buildComplianceReport };

--- a/tests/unit/complianceReport.test.js
+++ b/tests/unit/complianceReport.test.js
@@ -1,0 +1,44 @@
+const { buildComplianceReport } = require('../../lib/complianceReport');
+
+describe('ComplianceReport', () => {
+    test('builds KPI summary with totalArea and ilot dimensions', () => {
+        const floorPlan = {
+            totalArea: 200,
+            bounds: { minX: 0, minY: 0, maxX: 10, maxY: 20 }
+        };
+        const ilots = [
+            { width: 2, height: 3, area: 6 },
+            { width: 1.5, height: 4 }
+        ];
+        const corridors = [
+            { length: 10, area: 15 },
+            { width: 2, height: 6 }
+        ];
+        const unitMixReport = { summary: { weightedComplianceRate: 0.85 } };
+
+        const report = buildComplianceReport({
+            floorPlan,
+            ilots,
+            corridors,
+            unitMixReport
+        });
+
+        expect(report.kpis.usableArea).toBe(200);
+        expect(report.kpis.leasableArea).toBeCloseTo(12, 5);
+        expect(report.kpis.partitionLength).toBeCloseTo(2 * (2 + 3) + 2 * (1.5 + 4), 5);
+        expect(report.kpis.corridorArea).toBeCloseTo(15, 5);
+        expect(report.kpis.corridorLength).toBeCloseTo(10 + 6, 5);
+        expect(report.kpis.unitMixComplianceRate).toBe(0.85);
+        expect(report.assumptions.length).toBeGreaterThan(0);
+    });
+
+    test('uses bounds area when totalArea is missing', () => {
+        const floorPlan = { bounds: { minX: 0, minY: 0, maxX: 5, maxY: 5 } };
+        const report = buildComplianceReport({ floorPlan });
+
+        expect(report.kpis.usableArea).toBe(25);
+        expect(report.kpis.leasableArea).toBe(0);
+        expect(report.kpis.yieldRatio).toBe(0);
+        expect(report.assumptions[0]).toContain('bounds');
+    });
+});


### PR DESCRIPTION
### Motivation

- Provide a compact KPI rollup for layouts (leasable/usable area, yield, partition length, corridor metrics) to support compliance reporting.
- Make compliance data available to clients and downstream systems by returning the report after îlot generation and exposing an on-demand API. 
- Handle varied floor plan inputs robustly by deriving usable area from `totalArea`, `bounds`, or summed room areas. 

### Description

- Added a new module `lib/complianceReport.js` exporting `buildComplianceReport` which computes KPIs and assumptions and includes helpers like `resolveUsableArea`, `resolveIlotArea`, and `resolveCorridorLength`.
- Integrated the compliance report into the îlot generation flow by including `complianceReport` in the `/api/ilots` response using `ComplianceReport.buildComplianceReport`.
- Added a dedicated endpoint `POST /api/report/compliance` that accepts `floorPlan`, `ilots`, `corridors`, `unitMixReport`, and optional `validation` and returns the built report.
- Added unit tests `tests/unit/complianceReport.test.js` that validate KPI calculations and fallback behavior for area resolution. 

### Testing

- Ran the full test suite with `npm test`; the overall run reported failures (Test Suites: 1 failed, 13 passed, 14 total; Tests: 7 failed, 159 passed). 
- The new unit tests in `tests/unit/complianceReport.test.js` passed. 
- Failures observed are in unrelated areas and include `ProductionCorridorGenerator` unit tests and several integration/e2e tests that show îlot-count mismatches. 
- Console output and server startup logs were observed during test runs and show successful wiring of the new report generation into the server responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966869be6fc832089a4a46007a47874)