### PR TITLE
Fix: define ML bootstrap state

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,6 +29,8 @@ const UnitMixReport = require('./lib/unitMixReport');
 const ComplianceReport = require('./lib/complianceReport');
 const RuleManager = require('./lib/ruleManager');
 const ML_BOOT_PREFIX = '[Production ML System]';
+let mlBootstrapPromise = null;
+let mlBootstrapFinished = false;
 
 // --- RESTORED INITIALIZATION ---
 const PUBLIC_DIR = path.join(__dirname, 'public');
@@ -2122,4 +2124,3 @@ function scheduleMLBootstrap(reason = 'server-start') {
         });
     }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent a startup ReferenceError when `scheduleMLBootstrap` is invoked by ensuring the ML bootstrap state variables are defined.

### Description
- Define `mlBootstrapPromise` and `mlBootstrapFinished` at module scope (`let mlBootstrapPromise = null; let mlBootstrapFinished = false;`) so `scheduleMLBootstrap` can safely read/update them.

### Testing
- Ran `npm test` (Jest via `jest --runInBand`); the test run executed but the suite did not fully pass because several integration tests failed and some unit expectations in `productionCorridorGenerator` failed, with errors including `ReferenceError: sanitizeIlot is not defined` and missing/undefined properties in `ProductionCorridorGenerator`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696786daed3083209b1a510f7aaf95a4)