### PR TITLE
Fix: sync package-lock for npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2583,7 +2582,6 @@
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.22.0.tgz",
       "integrity": "sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "@types/offscreencanvas": "~2019.7.0",
@@ -3421,7 +3419,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8401,6 +8398,34 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/pg": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.1.tgz",
+      "integrity": "sha512-EIR+jXdYNSMOrpRp7g6WgQr7SaZNZfS7IzZIO0oTNEeibq956JxeD15t3Jk3zZH0KH8DmOIx38qJfQenoE8bXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pg-connection-string": "^2.10.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pg-cloudflare": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
@@ -9122,8 +9147,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -10112,7 +10136,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10426,7 +10449,6 @@
       "resolved": "https://registry.npmjs.org/vega/-/vega-5.20.0.tgz",
       "integrity": "sha512-L2hDaTH2gz9DFbu7l1B8fR637HzctViuosFCo/Db5aBe93fCJ/w/oJu+vQNfQELzfm9sntkS/+A4u+39xrDCNA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-crossfilter": "~4.0.5",
         "vega-dataflow": "~5.7.3",
@@ -10774,7 +10796,6 @@
       "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.13.1.tgz",
       "integrity": "sha512-OHZSSqVLuikoZ3idz3jIRk0UCKtVU2Lq5gaD6cLNTnJjNetoHKKdfZ023LVj4+Y9yWPz5meb+EJUsfBAGfF4Vw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/clone": "~0.1.30",
         "@types/fast-json-stable-stringify": "^2.0.0",
@@ -11560,7 +11581,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
### Motivation

- The Docker build was failing because `npm ci` complained that `package.json` and `package-lock.json` were out of sync due to an optional `pg` dependency missing from the lockfile. 
- Ensuring the lockfile reflects installed/optional packages allows reproducible installs in CI/container builds.

### Description

- Updated and synchronized `package-lock.json` so the optional `pg` dependency (and its transitive entries) are present and resolved. 
- Added a `node_modules/pg` entry for version `8.17.1` and adjusted related dependency metadata to match the current installed state. 
- This change is limited to the lockfile and does not modify `package.json` or source code.

### Testing

- Ran `npm ci` after syncing the lockfile and observed a successful install (warnings about deprecated packages only). 
- Ran `npm install` locally to produce the updated lockfile used for the sync. 
- Executed the test suite with `npm test`; unit tests passed but the integration suite had failures. 
- `npm test` result: unit tests ✅; integration tests ❌ with two failing tests: `should generate îlots with custom distribution` (returned 0 îlots) and `should generate corridors with facing row detection` (endpoint returned 400).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69692be6c1b08320b8a89bf6092749b4)