### PR TITLE
Normalize CAD layer names for robust classification

### DIFF
--- a/lib/cadEntityClassifier.js
+++ b/lib/cadEntityClassifier.js
@@ -5,6 +5,7 @@
 
 const mlProcessor = require('./mlProcessor');
 const dxfColorTable = require('./dxfColorTable');
+const { normalizeLayerName } = require('./layerNormalization');
 
 class CADEntityClassifier {
     constructor() {
@@ -15,13 +16,13 @@ class CADEntityClassifier {
      * Classify a CAD entity using ML processor
      */
     classifyEntity(entity) {
-        const layer = (entity.layer || '').toString().toUpperCase();
+        const layer = normalizeLayerName(entity.layer);
         const colorRaw = entity.color || 0;
         const color = dxfColorTable.normalizeDXFColor(colorRaw);
 
         // Prioritize layer-based classification first
         if (layer.includes('ENTRANCE') || layer.includes('EXIT') || layer.includes('DOOR') ||
-            layer.includes('OPENING') || layer.includes('RED') || layer === 'ENTREE__SORTIE' ||
+            layer.includes('OPENING') || layer.includes('RED') || layer === 'ENTREE_SORTIE' ||
             layer === 'DOORS') {
             return { type: 'entrance', confidence: 0.9 };
         } else if (layer.includes('FORBIDDEN') || layer.includes('STAIR') || layer.includes('ELEVATOR') ||
@@ -59,7 +60,7 @@ class CADEntityClassifier {
      * Extract features from CAD entity for ML classification
      */
     extractEntityFeatures(entity) {
-        const layer = (entity.layer || '').toLowerCase();
+        const layer = normalizeLayerName(entity.layer).toLowerCase();
         const color = entity.color || 0;
 
         // Calculate geometric properties
@@ -104,12 +105,12 @@ class CADEntityClassifier {
      * Fallback rule-based classification
      */
     fallbackClassification(entity) {
-        const layer = (entity.layer || '').toUpperCase();
+        const layer = normalizeLayerName(entity.layer);
         const color = entity.color || 0;
 
         // Layer-based classification first (higher priority)
         if (layer.includes('ENTRANCE') || layer.includes('EXIT') || layer.includes('DOOR') ||
-            layer.includes('OPENING') || layer.includes('RED') || layer === 'ENTREE__SORTIE' ||
+            layer.includes('OPENING') || layer.includes('RED') || layer === 'ENTREE_SORTIE' ||
             layer === 'DOORS') {
             return { type: 'entrance', confidence: 0.9 };
         } else if (layer.includes('FORBIDDEN') || layer.includes('STAIR') || layer.includes('ELEVATOR') ||

--- a/lib/cadProcessor.js
+++ b/lib/cadProcessor.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { normalizeLayerName } = require('./layerNormalization');
 
 class CADProcessor {
     constructor() {
@@ -203,8 +204,8 @@ class CADProcessor {
 
     isWall(entity) {
         if (entity.type === 'LINE') {
-            const layer = entity.layer.toLowerCase();
-            if (this.layerMappings.walls.some(w => layer.includes(w.toLowerCase()))) {
+            const layer = normalizeLayerName(entity.layer);
+            if (this.layerMappings.walls.some(w => layer.includes(normalizeLayerName(w)))) {
                 return true;
             }
             if (entity.color === 0 || entity.color === 7) {
@@ -215,8 +216,8 @@ class CADProcessor {
     }
 
     isForbiddenZone(entity) {
-        const layer = entity.layer.toLowerCase();
-        if (this.layerMappings.forbidden.some(f => layer.includes(f.toLowerCase()))) {
+        const layer = normalizeLayerName(entity.layer);
+        if (this.layerMappings.forbidden.some(f => layer.includes(normalizeLayerName(f)))) {
             return true;
         }
         if (entity.color === 5) {
@@ -226,8 +227,8 @@ class CADProcessor {
     }
 
     isEntrance(entity) {
-        const layer = entity.layer.toLowerCase();
-        if (this.layerMappings.entrances.some(e => layer.includes(e.toLowerCase()))) {
+        const layer = normalizeLayerName(entity.layer);
+        if (this.layerMappings.entrances.some(e => layer.includes(normalizeLayerName(e)))) {
             return true;
         }
         if (entity.color === 1) {

--- a/lib/cadStandards.js
+++ b/lib/cadStandards.js
@@ -12,12 +12,12 @@ const standards = {
         lineType: /^(Continuous|SOLID)$/i,
     },
     entrances: {
-        layer: /^(A-DOOR|ENTRANCES|ENTREE__SORTIE)$/i,
+        layer: /^(A-DOOR|ENTRANCES|ENTREE_+SORTIE)$/i,
         color: [255, 0, 0], // Red
         lineType: /^(Hidden|DASHED)$/i,
     },
     forbiddenZones: {
-        layer: /^(A-FLOR-FBDN|FORBIDDEN|NO_ENTREE)$/i,
+        layer: /^(A-FLOR-FBDN|FORBIDDEN|NO_+ENTREE)$/i,
         color: [0, 0, 255], // Blue
         lineType: /^(Phantom|DOTTED)$/i,
     },

--- a/lib/comprehensiveMLTrainingData.js
+++ b/lib/comprehensiveMLTrainingData.js
@@ -189,7 +189,7 @@ class ComprehensiveMLTrainingDataGenerator {
 
             entities.push({
                 type: 'entrance',
-                layer: this.randomChoice(['ENTREE__SORTIE', 'DOOR', 'DOORS', 'OPENING', 'ENTREE']),
+                layer: this.randomChoice(['ENTREE_SORTIE', 'DOOR', 'DOORS', 'OPENING', 'ENTREE']),
                 color: this.randomChoice([0xFF0000, 1, 10]), // Red, red index
                 area: Math.PI * arcRadius * arcRadius / 4,
                 perimeter: Math.PI * arcRadius / 2,

--- a/lib/dxfProcessor.js
+++ b/lib/dxfProcessor.js
@@ -1,5 +1,6 @@
 const DxfParser = require('dxf-parser');
 const cadEntityClassifier = require('./cadEntityClassifier');
+const { normalizeLayerName } = require('./layerNormalization');
 
 class DXFProcessor {
     processParsedDXF(dxf) {
@@ -22,7 +23,7 @@ class DXFProcessor {
         console.log(`[DXF Processor] Processing ${entities.length} entities`);
 
         for (const entity of entities) {
-            const layer = (entity.layer || '').toUpperCase();
+            const layer = normalizeLayerName(entity.layer);
             // Use proper color mapping: DXF colors are indexed, convert to RGB
             let color = entity.color || entity.colorIndex || 0;
 
@@ -44,7 +45,7 @@ class DXFProcessor {
                 };
 
                 // Always assign based on layer first, regardless of color index
-                if (layer === 'ENTREE__SORTIE' || layer === 'DOORS') {
+                if (layer === 'ENTREE_SORTIE' || layer === 'DOORS') {
                     color = 0xFF0000; // Red for entrances
                 } else if (layer === 'NO_ENTREE' || layer === 'STAIRS' || layer === 'CABINETRY' ||
                     layer === 'LIGHTING' || layer === 'POWER' || layer === 'APPLIANCES') {

--- a/lib/layerNormalization.js
+++ b/lib/layerNormalization.js
@@ -1,0 +1,17 @@
+const normalizeLayerName = (layerName) => {
+    if (!layerName) return '';
+
+    let normalized = layerName.toString();
+    normalized = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    normalized = normalized.trim().toUpperCase();
+    normalized = normalized.replace(/\s+/g, '_');
+    normalized = normalized.replace(/[^A-Z0-9_]/g, '_');
+    normalized = normalized.replace(/_+/g, '_');
+    normalized = normalized.replace(/^_+|_+$/g, '');
+
+    return normalized;
+};
+
+module.exports = {
+    normalizeLayerName
+};

--- a/lib/mlProcessor.js
+++ b/lib/mlProcessor.js
@@ -5,6 +5,7 @@
 
 const tf = require('@tensorflow/tfjs');
 const cadStandards = require('./cadStandards');
+const { normalizeLayerName } = require('./layerNormalization');
 
 class MLProcessor {
     constructor() {
@@ -337,7 +338,7 @@ class MLProcessor {
      */
     fallbackCADEntityClassification(entity) {
         const color = entity.color || 0;
-        const layer = (entity.layer || '').toUpperCase();
+        const layer = normalizeLayerName(entity.layer);
 
         // Color-based classification
         if (color === 0xFF0000 || color === 1) { // Red
@@ -372,7 +373,7 @@ class MLProcessor {
         }
 
         const issues = [];
-        const entityLayer = (entity.layer || '').toUpperCase();
+        const entityLayer = normalizeLayerName(entity.layer);
         const entityColor = entity.color || 0;
 
         // Check layer name

--- a/lib/professionalCADProcessor.js
+++ b/lib/professionalCADProcessor.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const DxfParser = require('dxf-parser');
 const dxfProcessor = require('./dxfProcessor');
+const { normalizeLayerName } = require('./layerNormalization');
 
 // Cache the wasm-backed LibreDwg instance so we don't re-initialize the module on each request
 let cachedLibreDwg = null;
@@ -294,6 +295,7 @@ class ProfessionalCADProcessor {
             };
 
             const layerVal = getFirst(8) || '';
+            const normalizedLayer = normalizeLayerName(layerVal);
             let colorVal = parseInt(getFirst(62) || '0') || 0;
 
             // Convert DXF color index to RGB - use layer-based defaults if color is 0
@@ -313,11 +315,11 @@ class ProfessionalCADProcessor {
 
                 // If color is 0 (default), assign based on layer
                 if (colorVal === 0) {
-                    if (layerVal.toUpperCase() === 'ENTREE__SORTIE') {
+                    if (normalizedLayer === 'ENTREE_SORTIE') {
                         colorVal = 0xFF0000; // Red for entrances
-                    } else if (layerVal.toUpperCase() === 'NO_ENTREE') {
+                    } else if (normalizedLayer === 'NO_ENTREE') {
                         colorVal = 0x0000FF; // Blue for forbidden zones
-                    } else if (layerVal.toUpperCase() === 'MUR') {
+                    } else if (normalizedLayer === 'MUR') {
                         colorVal = 0x000000; // Black for walls
                     } else {
                         colorVal = dxfColors[colorVal] || 0x000000;
@@ -340,7 +342,7 @@ class ProfessionalCADProcessor {
                         type: 'line',
                         start: { x: x1v, y: y1v },
                         end: { x: x2v, y: y2v },
-                        layer: (layerVal || '').toUpperCase(),
+                        layer: normalizedLayer,
                         color: colorVal,
                         length: Math.hypot(x2v - x1v, y2v - y1v)
                     };
@@ -363,7 +365,7 @@ class ProfessionalCADProcessor {
                             type: 'arc',
                             start: segA[0],
                             end: segA[1],
-                            layer: (layerVal || '').toUpperCase(),
+                            layer: normalizedLayer,
                             color: colorVal,
                             radius: r,
                             center: { x: cx, y: cy }
@@ -372,7 +374,7 @@ class ProfessionalCADProcessor {
                         this.updateBounds(segA[0].x, segA[0].y);
                         this.updateBounds(segA[1].x, segA[1].y);
                     }
-                    this._trackLayer((layerVal || '').toUpperCase());
+                    this._trackLayer(normalizedLayer);
                 }
             } else if (ent === 'CIRCLE') {
                 const cx = parseFloat(getFirst(10));
@@ -386,7 +388,7 @@ class ProfessionalCADProcessor {
                             type: 'circle',
                             start: segC[0],
                             end: segC[1],
-                            layer: (layerVal || '').toUpperCase(),
+                            layer: normalizedLayer,
                             color: colorVal,
                             radius: r,
                             center: { x: cx, y: cy }
@@ -395,7 +397,7 @@ class ProfessionalCADProcessor {
                         this.updateBounds(segC[0].x, segC[0].y);
                         this.updateBounds(segC[1].x, segC[1].y);
                     }
-                    this._trackLayer((layerVal || '').toUpperCase());
+                    this._trackLayer(normalizedLayer);
                 }
             } else if (ent === 'LWPOLYLINE' || ent === 'POLYLINE') {
                 // collect vertices from blockPairs: codes 10/20 pairs and optional 42 bulge
@@ -414,7 +416,7 @@ class ProfessionalCADProcessor {
                     }
                 }
                 if (verts.length >= 2) {
-                    this._flushLwpolyToSegments(verts, segments, layerVal, colorVal);
+                    this._flushLwpolyToSegments(verts, segments, normalizedLayer, colorVal);
                 }
             }
 
@@ -428,7 +430,7 @@ class ProfessionalCADProcessor {
         // Classify polygons and remaining segments
         for (const p of polygons) {
             // p has { polygon: [ [x,y], ... ], color, layer }
-            const layer = (p.layer || '').toUpperCase();
+            const layer = normalizeLayerName(p.layer);
 
             // Detect entrances by color or layer name
             if (p.color === 1 || p.color === 3 ||
@@ -509,7 +511,7 @@ class ProfessionalCADProcessor {
      * Color codes: 1=red (entrances), 5=blue (forbidden), 0/7=black/white (walls)
      */
     classifyLine(line) {
-        const layer = line.layer.toUpperCase();
+        const layer = normalizeLayerName(line.layer);
         const color = line.color;
 
         // Enhanced layer-based classification
@@ -773,6 +775,7 @@ ProfessionalCADProcessor.prototype._arcToSegments = function (center, r, startAn
  */
 ProfessionalCADProcessor.prototype._flushLwpolyToSegments = function (vertices, segmentsArray, layer, color) {
     if (!vertices || vertices.length < 2) return;
+    const normalizedLayer = normalizeLayerName(layer);
     for (let i = 0; i < vertices.length - 1; i++) {
         const v1 = vertices[i];
         const v2 = vertices[i + 1];
@@ -783,7 +786,7 @@ ProfessionalCADProcessor.prototype._flushLwpolyToSegments = function (vertices, 
                 type: 'line',
                 start: { x: v1.x, y: v1.y },
                 end: { x: v2.x, y: v2.y },
-                layer: (layer || '').toUpperCase(),
+                layer: normalizedLayer,
                 color,
                 length: Math.hypot(v2.x - v1.x, v2.y - v1.y)
             });
@@ -810,7 +813,7 @@ ProfessionalCADProcessor.prototype._flushLwpolyToSegments = function (vertices, 
                     type: 'arc_segment',
                     start: seg[0],
                     end: seg[1],
-                    layer: (layer || '').toUpperCase(),
+                    layer: normalizedLayer,
                     color,
                     bulge
                 });

--- a/lib/realCADProcessor.js
+++ b/lib/realCADProcessor.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { normalizeLayerName } = require('./layerNormalization');
 
 class RealCADProcessor {
     constructor() {
@@ -124,12 +125,12 @@ class RealCADProcessor {
             this.updateBounds(entity.x2 || entity.x1, entity.y2 || entity.y1);
             
             // Classify by layer and color
-            const layer = entity.layer.toLowerCase();
+            const layer = normalizeLayerName(entity.layer);
             const color = entity.color;
             
-            if (color === 5 || layer.includes('blue') || layer.includes('forbidden')) {
+            if (color === 5 || layer.includes('BLUE') || layer.includes('FORBIDDEN')) {
                 this.forbiddenZones.push(line);
-            } else if (color === 1 || layer.includes('red') || layer.includes('door') || layer.includes('entrance')) {
+            } else if (color === 1 || layer.includes('RED') || layer.includes('DOOR') || layer.includes('ENTRANCE')) {
                 this.entrances.push(line);
             } else {
                 this.walls.push(line);


### PR DESCRIPTION
### Motivation

- Real-world DXF files include inconsistent layer naming (spaces, diacritics, mixed punctuation) which breaks hard-coded matching like `ENTREE__SORTIE` and `NO_ENTREE`. 
- The goal is to canonicalize layer names repository-wide so classifiers, processors and ML/validation see a stable representation. 

### Description

- Add `lib/layerNormalization.js` providing `normalizeLayerName` that removes diacritics, trims, uppercases, collapses whitespace/punctuation to underscores, and strips leading/trailing underscores. 
- Wire the normalizer into DXF/DWG processing and classification by updating `lib/dxfProcessor.js`, `lib/professionalCADProcessor.js`, `lib/cadProcessor.js`, `lib/realCADProcessor.js`, and `lib/cadEntityClassifier.js` to use normalized layer names for matching and tracking. 
- Update ML/validation and standards to use normalized layers by modifying `lib/mlProcessor.js`, `lib/cadStandards.js`, and training data in `lib/comprehensiveMLTrainingData.js` to accept underscore-collapsed patterns like `ENTREE_SORTIE` and `NO_ENTREE`. 
- Ensure layer-based color heuristics and polygon/segment tracking use the canonical layer values so detection of entrances/forbidden zones/walls is robust to spacing and punctuation variants. 

### Testing

- Ran the full test suite with `npm test`, which executed unit, integration and E2E tests and completed successfully. 
- Test summary: all test suites passed (17 test suites, 214 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a5c8d2b9083208ffafbe9271f61ca)