### PR TITLE
Fix grid extractor ignoring manual distribution when unit mix is present

### DIFF
--- a/lib/gridCellExtractor.js
+++ b/lib/gridCellExtractor.js
@@ -175,16 +175,8 @@ function estimateCellDimensions(distribution, unitMix, options = {}) {
     const aspectRatio = Number.isFinite(options.cellAspectRatio) ? options.cellAspectRatio : 0.5;
     let avgArea = null;
 
-    if (Array.isArray(unitMix) && unitMix.length) {
-        const areas = unitMix
-            .map((t) => Number(t.targetArea || t.area || t.surface || t.target))
-            .filter((v) => Number.isFinite(v) && v > 0);
-        if (areas.length) {
-            avgArea = areas.reduce((sum, v) => sum + v, 0) / areas.length;
-        }
-    }
-
-    if (!Number.isFinite(avgArea) && distribution && typeof distribution === 'object') {
+    // Prioritize distribution if available (allows manual overrides)
+    if (distribution && typeof distribution === 'object') {
         let totalWeight = 0;
         let weightedArea = 0;
         Object.entries(distribution).forEach(([range, weightRaw]) => {
@@ -204,6 +196,17 @@ function estimateCellDimensions(distribution, unitMix, options = {}) {
             avgArea = weightedArea / totalWeight;
         }
     }
+
+    // Fallback to unit mix if distribution is missing or invalid
+    if ((!Number.isFinite(avgArea) || avgArea <= 0) && Array.isArray(unitMix) && unitMix.length) {
+        const areas = unitMix
+            .map((t) => Number(t.targetArea || t.area || t.surface || t.target))
+            .filter((v) => Number.isFinite(v) && v > 0);
+        if (areas.length) {
+            avgArea = areas.reduce((sum, v) => sum + v, 0) / areas.length;
+        }
+    }
+
 
     if (!Number.isFinite(avgArea) || avgArea <= 0) {
         avgArea = 2.2;


### PR DESCRIPTION
The issue was that `lib/gridCellExtractor.js` (used as a fallback strategy for ilot generation) was prioritizing `unitMix` data over the `distribution` object when calculating the grid cell size. This meant that if a user loaded a Unit Mix file (setting `unitMix`), any subsequent manual adjustments to the distribution sliders (updating `distribution`) were ignored by the fallback generator, resulting in a static layout.

I reversed the priority order in `estimateCellDimensions`:
1. It now attempts to calculate the weighted average area from the `distribution` object first.
2. If that fails (e.g. `distribution` is missing or invalid), it falls back to the `unitMix` average area.

This ensures that the "Generate Ilots" button respects the current UI state (distribution sliders) even when a unit mix file has been imported. I verified this behavior with a reproduction script that confirmed the distribution is now prioritized. I also ran the test suite to ensure no regressions in related functionality.

---
*PR created automatically by Jules for task [938594541809453442](https://jules.google.com/task/938594541809453442) started by @rehmanul*